### PR TITLE
docs: remove nonexistent mdformat-* commands from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Make sure to run `bun install` first!
 
 ### Other Commands
 
-Run `just` to see all available commands, including `prettier-*`, `mdformat-*`, and `knip-*`.
+Run `just` to see all available commands, including `prettier-*` and `knip-*`.
 
 ## Project Structure
 


### PR DESCRIPTION
The README lists `mdformat-*` among the available `just` commands:

> Run `just` to see all available commands, including `prettier-*`, `mdformat-*`, and `knip-*`.

But there is no `mdformat` recipe — not in this repo's `justfile`, and not in the imported `@prb/devkit` `just/base.just` (which provides `prettier-check/write` and `knip-check/write`). `mdformat` appears only in this one README line; running `just mdformat-check` fails with `Justfile does not contain recipe`.

This drops the stale reference. `prettier-*` and `knip-*` are unchanged (both are real). Docs-only.
